### PR TITLE
fix(deps): locate SignalR.Server 3.0.0-rc1-final

### DIFF
--- a/AureliaAspNetCoreAuth.sln
+++ b/AureliaAspNetCoreAuth.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E90A90EB-ECB0-4428-B967-4DEDCDA11AF0}"
 	ProjectSection(SolutionItems) = preProject
 		global.json = global.json
+		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AureliaAspNetCoreAuth", "src\AureliaAspNetCoreAuth\AureliaAspNetCoreAuth.xproj", "{D0F2902E-8B03-4A96-84D8-F2F64268C4F4}"

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="aspnetmaster" value="https://www.myget.org/F/aspnetmaster/api/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Error message is:
Unable to locate Dependency Microsoft.AspNet.SignalR.Server >= 3.0.0-rc1-final

Solution reference: 
http://stackoverflow.com/questions/33866010/signalr-not-working-in-asp-net-5-rc-1
